### PR TITLE
Fix tester entry for orchestrator

### DIFF
--- a/agents/tech/tester.py
+++ b/agents/tech/tester.py
@@ -101,5 +101,10 @@ def tester(task_spec) -> dict:
     }
 
 
+def run(task_spec) -> dict:
+    """Public wrapper used by the orchestrator."""
+    return tester(task_spec)
+
+
 if __name__ == "__main__":
     print(json.dumps(tester({}), indent=2, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- add a `run` wrapper in `agents/tech/tester.py` so the orchestrator can invoke the tester

## Testing
- `pre-commit run --files agents/tech/tester.py`

------
https://chatgpt.com/codex/tasks/task_e_686ba2c2ec488320b846216b58eec97d