### PR TITLE
Add creative pipeline and local LLM integration

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -6,3 +6,5 @@ project_manager = import_module("agents.tech.project_manager")
 coder = import_module("agents.tech.coder")
 tester = import_module("agents.tech.tester")
 team_lead = import_module("agents.tech.team_lead")
+
+creative_orchestrator = import_module("agents.creative.creative_orchestrator")

--- a/agents/creative/__init__.py
+++ b/agents/creative/__init__.py
@@ -1,0 +1,8 @@
+from importlib import import_module
+
+# Re-export creative agents for convenience
+creative_orchestrator = import_module("agents.creative.creative_orchestrator")
+GameDesigner = import_module("agents.creative.game_designer")
+narrative_designer = import_module("agents.creative.narrative_designer")
+lore_keeper = import_module("agents.creative.lore_keeper")
+art_mood = import_module("agents.creative.art_mood")

--- a/agents/creative/art_mood.py
+++ b/agents/creative/art_mood.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from utils.llm import ask_mistral
+
+
+def run(input: dict) -> dict:
+    """Generate a textual mood board description."""
+    idea = input.get("text", "")
+    prompt = "Create a one-paragraph mood board description for this game idea:\n" + idea
+    description = ask_mistral(prompt)
+    mood_dir = Path("moodboards")
+    mood_dir.mkdir(exist_ok=True)
+    path = mood_dir / "mood.txt"
+    path.write_text(description, encoding="utf-8")
+    return {"moodboard": str(path)}

--- a/agents/creative/creative_orchestrator.py
+++ b/agents/creative/creative_orchestrator.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+from . import game_designer, narrative_designer, lore_keeper, art_mood
+
+
+def run(input: dict) -> dict:
+    """Run the creative pipeline and store idea_spec.json."""
+    idea_text = input.get("text", "")
+    gd = game_designer.run({"text": idea_text})
+    scene = narrative_designer.run(gd)
+    lore = lore_keeper.run(scene)
+    mood = art_mood.run({"text": idea_text})
+    spec = {
+        "core_loop": gd.get("core_loop"),
+        "scene": scene.get("scene"),
+        "lorebook": lore.get("lorebook"),
+        "moodboard": mood.get("moodboard"),
+    }
+    Path("idea_spec.json").write_text(json.dumps(spec, indent=2, ensure_ascii=False), encoding="utf-8")
+    return spec

--- a/agents/creative/game_designer.py
+++ b/agents/creative/game_designer.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from utils.llm import ask_mistral
+
+
+def run(input: dict) -> dict:
+    """Generate a short core loop description using local LLM."""
+    idea = input.get("text", "").strip()
+    if not idea:
+        return {"core_loop": ""}
+    prompt = (
+        "Design a concise core gameplay loop for the following idea. "
+        "Respond with a paragraph under 100 words.\n" + idea
+    )
+    core_loop = ask_mistral(prompt)
+    Path("core_loop.md").write_text(core_loop, encoding="utf-8")
+    return {"core_loop": core_loop, "file": "core_loop.md"}

--- a/agents/creative/lore_keeper.py
+++ b/agents/creative/lore_keeper.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+from utils.llm import ask_mistral
+
+
+def run(input: dict) -> dict:
+    """Update lorebook with facts extracted from the narrative scene."""
+    scene_file = input.get("scene")
+    text = ""
+    if scene_file and Path(scene_file).exists():
+        text = Path(scene_file).read_text(encoding="utf-8")
+    prompt = (
+        "Extract key lore facts from the following narrative scene and return "
+        "them as a JSON object of named facts.\n" + text
+    )
+    reply = ask_mistral(prompt)
+    lore_path = Path("lorebook.json")
+    if lore_path.exists():
+        lore = json.loads(lore_path.read_text(encoding="utf-8"))
+    else:
+        lore = {}
+    try:
+        facts = json.loads(reply)
+        if isinstance(facts, dict):
+            lore.update(facts)
+        else:
+            lore[str(len(lore))] = facts
+    except json.JSONDecodeError:
+        lore[str(len(lore))] = reply
+    lore_path.write_text(json.dumps(lore, indent=2, ensure_ascii=False), encoding="utf-8")
+    return {"lorebook": str(lore_path)}

--- a/agents/creative/narrative_designer.py
+++ b/agents/creative/narrative_designer.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+from utils.llm import ask_mistral
+
+
+def run(input: dict) -> dict:
+    """Create a simple narrative event JSON based on core loop."""
+    core_loop = input.get("core_loop", "")
+    prompt = (
+        "Create a short intro scene for the following game core loop as JSON with "
+        "fields 'scene' and 'dialogue' (list of lines).\n" + core_loop
+    )
+    reply = ask_mistral(prompt)
+    scene_dir = Path("narrative_events")
+    scene_dir.mkdir(parents=True, exist_ok=True)
+    scene_path = scene_dir / "scene_1.json"
+    try:
+        json.loads(reply)
+        scene_path.write_text(reply, encoding="utf-8")
+    except json.JSONDecodeError:
+        scene = {"scene": "intro", "dialogue": [reply]}
+        scene_path.write_text(json.dumps(scene, indent=2, ensure_ascii=False), encoding="utf-8")
+    return {"scene": str(scene_path)}

--- a/agents/tech/coder.py
+++ b/agents/tech/coder.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 from pathlib import Path
 
+from utils.llm import ask_mistral
+
 
 def coder(task_spec):
-    """Generate a simple C# helper file patch."""
-    path = task_spec.get("path", "Generated/Helper.cs")
+    """Generate a C# script using local LLM."""
+    path = task_spec.get("path", "Generated/Feature.cs")
     namespace = task_spec.get("namespace", "AIUnityStudio.Generated")
+    feature = task_spec.get("feature", "")
 
     class_name = Path(path).stem
-    code = (
-        f"namespace {namespace} {{\n"
-        f"    public static class {class_name} {{\n"
-        f"        public static int Square(int x) => x * x;\n"
-        f"    }}\n"
-        f"}}\n"
+    prompt = (
+        f"Write a Unity C# script called {class_name} in namespace {namespace}. "
+        f"The script should implement: {feature}. Provide only the code."
     )
+    code = ask_mistral(prompt)
+
+    if "namespace" not in code:
+        code = f"namespace {namespace} {{\n{code}\n}}"
 
     return {
         "modifications": [

--- a/agents/tech/game_designer.py
+++ b/agents/tech/game_designer.py
@@ -1,5 +1,7 @@
 # agents/tech/game_designer.py
-"""Stub agent to convert text prompt into feature description."""
+"""Generate short feature description using local LLM."""
+
+from utils.llm import ask_mistral
 
 
 def run(input: dict) -> dict:
@@ -10,4 +12,8 @@ def run(input: dict) -> dict:
         dict: {"feature": <короткое описание>}
     """
     text = input.get("text", "").strip()
-    return {"feature": text or "stub feature"}
+    if not text:
+        return {"feature": "stub feature"}
+    prompt = "Summarise the following game feature idea in one short sentence:\n" + text
+    feature = ask_mistral(prompt)
+    return {"feature": feature or text}

--- a/agents/tech/orchestrator.py
+++ b/agents/tech/orchestrator.py
@@ -11,6 +11,7 @@ from agents.tech import (
     refactor_agent,
     team_lead,
 )
+from agents.creative import creative_orchestrator
 from utils import apply_patch
 from utils.dotnet_tools import run_dotnet_build
 import config
@@ -18,6 +19,9 @@ import config
 
 def main(text: str):
     team_lead.log("🚀 Start AI pipeline")
+
+    creative_spec = creative_orchestrator.run({"text": text})
+    team_lead.log(f"🎭 Creative spec: {json.dumps(creative_spec, ensure_ascii=False)}")
 
     feature = game_designer.run({"text": text})
     team_lead.log(f"🎮 Feature: {json.dumps(feature, ensure_ascii=False)}")

--- a/agents/tech/project_manager.py
+++ b/agents/tech/project_manager.py
@@ -1,5 +1,8 @@
 # agents/tech/project_manager.py
-"""Stub project manager that converts feature to a single task list."""
+"""Plan tasks for a feature using local LLM."""
+
+import json
+from utils.llm import ask_mistral
 
 
 def run(feature: dict) -> dict:
@@ -9,4 +12,17 @@ def run(feature: dict) -> dict:
     Returns:
         {"tasks": [ { "feature": <текст>, "acceptance": ["Compiles"] } ]}
     """
-    return {"tasks": [{"feature": feature["feature"], "acceptance": ["Compiles"]}]}
+    desc = feature.get("feature", "")
+    prompt = (
+        "Create 3 short development tasks to implement the following Unity feature. "
+        'Respond with JSON in the form {"tasks": [{"feature": str, "acceptance": [str]}]}\n' + desc
+    )
+    reply = ask_mistral(prompt)
+    try:
+        data = json.loads(reply)
+        tasks = data.get("tasks")
+        if isinstance(tasks, list):
+            return {"tasks": tasks}
+    except json.JSONDecodeError:
+        pass
+    return {"tasks": [{"feature": desc, "acceptance": ["Compiles"]}]}

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ load_dotenv()
 PROJECT_PATH = os.getenv("PROJECT_PATH")
 UNITY_CLI = os.getenv("UNITY_CLI")
 UNITY_SCRIPTS_PATH = os.getenv("UNITY_SCRIPTS_PATH")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")  # optional for local LLM
 
 if not PROJECT_PATH:
     raise ValueError("❌ PROJECT_PATH не задан в .env")
@@ -14,5 +14,3 @@ if not UNITY_CLI:
     raise ValueError("❌ UNITY_CLI не задан в .env")
 if not UNITY_SCRIPTS_PATH:
     raise ValueError("❌ UNITY_SCRIPTS_PATH не задан в .env")
-if not OPENAI_API_KEY:
-    raise ValueError("❌ OPENAI_API_KEY не задан в .env")

--- a/tools/mapctl.py
+++ b/tools/mapctl.py
@@ -39,7 +39,11 @@ def validate():
 
     try:
         data = json.loads(PM_PATH.read_text(encoding="utf-8"))
-        ProjectMap.model_validate(data, strict=True)  # pydantic v2
+        # Compatible validation for both pydantic v1 and v2
+        if hasattr(ProjectMap, "model_validate"):
+            ProjectMap.model_validate(data, strict=True)
+        else:
+            ProjectMap.parse_obj(data)
         click.secho("[OK] project_map.json is valid", fg="green")
         sys.exit(0)
     except (json.JSONDecodeError, ValidationError) as err:

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -1,0 +1,18 @@
+import json
+import requests
+
+
+def ask_mistral(prompt: str, model: str = "mistral") -> str:
+    """Query local Mistral LLM via Ollama REST API."""
+    try:
+        response = requests.post(
+            "http://localhost:11434/api/generate",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"model": model, "prompt": prompt, "stream": False}),
+            timeout=30,
+        )
+        response.raise_for_status()
+        result = response.json()
+        return result.get("response", "").strip()
+    except requests.exceptions.RequestException as exc:
+        return f"⚠ LLM error: {exc}".strip()


### PR DESCRIPTION
## Summary
- add simple Ollama-based LLM helper
- implement creative agents and orchestrator
- enhance tech agents to use local LLM
- integrate creative step into orchestrator
- make OPENAI_API_KEY optional
- ensure mapctl works with pydantic v1

## Testing
- `pre-commit run --files agents/__init__.py agents/creative/__init__.py agents/creative/game_designer.py agents/creative/narrative_designer.py agents/creative/lore_keeper.py agents/creative/art_mood.py agents/creative/creative_orchestrator.py agents/tech/coder.py agents/tech/game_designer.py agents/tech/orchestrator.py agents/tech/project_manager.py config.py utils/llm.py tools/mapctl.py`

------
https://chatgpt.com/codex/tasks/task_e_686ba96e62248320908352c002528cb4