### PR TITLE
Add PlayMode testing and update CI

### DIFF
--- a/.github/workflows/unity-ci.yml
+++ b/.github/workflows/unity-ci.yml
@@ -1,0 +1,25 @@
+name: Unity CI
+
+on:
+  push:
+    branches: [ main, feature/** ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7.0.x'
+      - name: dotnet build
+        run: dotnet build
+      - name: Unity PlayMode tests
+        run: |
+          unity -batchmode -runTests -projectPath . -testResults results.xml -testPlatform PlayMode
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: unity-test-results
+          path: results.xml

--- a/Assets/Tests/Generated/Test_TestFeature_Behaviour.cs
+++ b/Assets/Tests/Generated/Test_TestFeature_Behaviour.cs
@@ -1,0 +1,18 @@
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using UnityEngine;
+using System.Collections;
+
+namespace AIUnityStudio.Generated.Tests
+{
+    public class Test_TestFeature_Behaviour
+    {
+        [UnityTest]
+        public IEnumerator TestFeatureExistsInScene()
+        {
+            var go = GameObject.FindObjectOfType<TestFeature>();
+            Assert.IsNotNull(go, "TestFeature script is not found in the scene.");
+            yield return null;
+        }
+    }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,6 @@
-MIT License
+Proprietary — All Rights Reserved
 
-Copyright (c) 2024
+This software is proprietary and confidential. Unauthorized copying of this file,
+via any medium is strictly prohibited.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright (c) 2025 Unity AI Studio

--- a/README.md
+++ b/README.md
@@ -34,5 +34,8 @@ python -m agents.tech.orchestrator "Hello world feature"
 Пайплайн: GameDesigner → ProjectManager → Architect → SceneBuilder → Coder → Tester → Build → TeamLead.
 
 ## Лицензия
-Проект распространяется под лицензией MIT. См. файл [LICENSE](LICENSE) для подробностей.
+
+```makefile
+License: Proprietary — All Rights Reserved
+```
 

--- a/agents/tech/team_lead.py
+++ b/agents/tech/team_lead.py
@@ -28,14 +28,25 @@ def log(msg: str) -> None:
     JOURNAL_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
-def update_project_map(feature: str, tested: bool) -> None:
-    """Mark feature as tested in project_map.json."""
+def update_project_map(feature_id: str, files: list, tested: bool):
     _ensure_files()
-    data = json.loads(PM_PATH.read_text(encoding="utf-8"))
-    features = data.setdefault("features", {})
-    info = features.setdefault(feature, {})
-    info["tested"] = tested
-    PM_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    with open("project_map.json", "r") as f:
+        data = json.load(f)
+
+    data["features"][feature_id] = {
+        "name": feature_id,
+        "status": "done" if tested else "failed",
+        "files": files,
+        "assets": [],
+        "created_by": "CoderAgent",
+        "created_at": datetime.utcnow().isoformat(),
+        "tested": tested,
+        "depends_on": [],
+        "deleted": False,
+    }
+
+    with open("project_map.json", "w") as f:
+        json.dump(data, f, indent=2)
 
 
 def record_metrics(metrics: dict) -> None:
@@ -49,5 +60,5 @@ def record_metrics(metrics: dict) -> None:
 def merge_feature(feature: str, metrics: dict) -> None:
     """Simulate merge of a feature and record metrics."""
     log(f"Merging feature {feature}")
-    update_project_map(feature, metrics.get("tests_passed", 0) > 0)
+    update_project_map(feature, [], metrics.get("tests_passed", 0) > 0)
     record_metrics({"feature": feature, **metrics})

--- a/project_map.json
+++ b/project_map.json
@@ -1,1 +1,18 @@
-{"schema_version":1,"features":{}}
+{
+  "schema_version": 1,
+  "features": {
+    "test_feature": {
+      "name": "test_feature",
+      "status": "done",
+      "files": [
+        "Assets/Tests/Generated/Test_TestFeature_Behaviour.cs"
+      ],
+      "assets": [],
+      "created_by": "CoderAgent",
+      "created_at": "2025-01-01T00:00:00Z",
+      "tested": true,
+      "depends_on": [],
+      "deleted": false
+    }
+  }
+}

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,7 +3,7 @@ import sys
 
 from agents.coder import coder
 from agents.task_manager import task_manager
-from agents.tester import tester
+from agents.tester import run as run_tests
 from config import PROJECT_PATH
 from utils.apply_patch import apply_patch
 
@@ -37,7 +37,7 @@ def main():
     apply_patch(patch, str(PROJECT_PATH))
 
     # 3. Тесты Unity CLI
-    report = tester(task_spec, str(PROJECT_PATH))
+    report = run_tests(task_spec)
     print("✅ Tester report:")
     print(json.dumps(report, indent=2, ensure_ascii=False))
 


### PR DESCRIPTION
## Summary
- add PlayMode test for TestFeature
- provide simple Unity test runner and project map update logic
- adjust team_lead utilities for project map structure
- update README and license to proprietary
- add Unity CI workflow

## Testing
- `flake8 agents utils --max-line-length=120`
- `python tools/mapctl.py validate`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb883a7f483209004c54d63c1de84