### PR TITLE
Add editmode tests and unified test runner

### DIFF
--- a/.github/workflows/unity-ci.yml
+++ b/.github/workflows/unity-ci.yml
@@ -1,0 +1,30 @@
+name: Unity CI
+
+on:
+  push:
+    branches: [ main, feature/** ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7.0.x'
+      - name: dotnet build
+        run: dotnet build
+      - name: Unity EditMode tests
+        run: |
+          unity -batchmode -runTests -projectPath . -testResults results_EditMode.xml -testPlatform EditMode
+      - name: Unity PlayMode tests
+        run: |
+          unity -batchmode -runTests -projectPath . -testResults results_PlayMode.xml -testPlatform PlayMode
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: unity-test-results
+          path: |
+            results_EditMode.xml
+            results_PlayMode.xml

--- a/Assets/Scripts/Generated/TestFeature.cs
+++ b/Assets/Scripts/Generated/TestFeature.cs
@@ -1,0 +1,6 @@
+namespace AIUnityStudio.Generated
+{
+    public class TestFeature
+    {
+    }
+}

--- a/Assets/Tests/Generated/Test_TestFeature_Logic.cs
+++ b/Assets/Tests/Generated/Test_TestFeature_Logic.cs
@@ -1,0 +1,15 @@
+using NUnit.Framework;
+using AIUnityStudio.Generated;
+
+namespace AIUnityStudio.Generated.Tests
+{
+    public class Test_TestFeature_Logic
+    {
+        [Test]
+        public void TestFeature_CanBeInstantiated()
+        {
+            var instance = new TestFeature();
+            Assert.IsNotNull(instance);
+        }
+    }
+}

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -1,0 +1,5 @@
+from agents.tech.tester import run_unity_tests
+
+if __name__ == '__main__':
+    results = run_unity_tests('.')
+    print('Test metrics:', results)


### PR DESCRIPTION
## Summary
- add simple EditMode test for `TestFeature`
- implement `run_unity_tests` helper and update tester
- generate `metrics.json` from Unity test results
- add workflow running EditMode and PlayMode tests
- add local runner script

## Testing
- `flake8 agents utils tools --max-line-length=120`
- `PYTHONPATH=. python tools/run_tests.py` *(fails: FileNotFoundError: unity)*

------
https://chatgpt.com/codex/tasks/task_e_686bba653b6883209a88cd2bda962c78