### PR TITLE
Implement CI utilities and fallback helper

### DIFF
--- a/ci_publish.py
+++ b/ci_publish.py
@@ -1,0 +1,57 @@
+"""Upload build artifacts to an S3 compatible storage."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import boto3
+from dotenv import load_dotenv
+
+
+def _load_env() -> dict[str, str]:
+    load_dotenv()
+    required = [
+        "S3_ENDPOINT",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        "S3_BUCKET",
+    ]
+    config = {var: os.getenv(var) for var in required}
+    missing = [k for k, v in config.items() if not v]
+    if missing:
+        raise RuntimeError(f"Missing env variables: {', '.join(missing)}")
+    return config
+
+
+def _get_client(cfg: dict[str, str]):
+    return boto3.client(
+        "s3",
+        endpoint_url=cfg["S3_ENDPOINT"],
+        aws_access_key_id=cfg["S3_ACCESS_KEY"],
+        aws_secret_access_key=cfg["S3_SECRET_KEY"],
+    )
+
+
+def _upload_file(client, bucket: str, path: Path) -> None:
+    key = path.name
+    client.upload_file(str(path), bucket, key)
+    print(f"Uploaded {path} -> {bucket}/{key}")
+
+
+def main() -> None:
+    cfg = _load_env()
+    client = _get_client(cfg)
+    bucket = cfg["S3_BUCKET"]
+
+    artifacts = []
+    reports_dir = Path("ci_reports")
+    if reports_dir.exists():
+        artifacts.extend(p for p in reports_dir.iterdir() if p.suffix in {".zip", ".apk"})
+
+    for path in artifacts:
+        _upload_file(client, bucket, path)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,0 +1,10 @@
+boto3>=1.34
+click>=8.1
+flake8>=7.0
+GitPython>=3.1
+openai>=1.30
+pytest>=8.0
+pydantic>=2.0
+python-dotenv>=1.0
+requests>=2.0
+# unity-cli

--- a/tools/gen_changelog.py
+++ b/tools/gen_changelog.py
@@ -1,0 +1,44 @@
+"""Generate CHANGELOG.md from agent_journal.log grouped by agent."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+LOG_PATH = Path("agent_journal.log")
+CHANGELOG_PATH = Path("CHANGELOG.md")
+LINE_RE = re.compile(r"^(\S+) \[(.+?)\] (.+)$")
+
+
+def parse_log() -> dict[str, list[str]]:
+    entries: dict[str, list[str]] = defaultdict(list)
+    if not LOG_PATH.exists():
+        return entries
+    for line in LOG_PATH.read_text(encoding="utf-8").splitlines():
+        match = LINE_RE.match(line)
+        if not match:
+            continue
+        timestamp, agent, message = match.groups()
+        entries[agent].append(f"{timestamp} {message}")
+    return entries
+
+
+def render(entries: dict[str, list[str]]) -> str:
+    lines = ["# Changelog"]
+    for agent, messages in entries.items():
+        lines.append(f"\n## {agent}")
+        for msg in messages:
+            lines.append(f"- {msg}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    entries = parse_log()
+    text = render(entries)
+    CHANGELOG_PATH.write_text(text, encoding="utf-8")
+    print("CHANGELOG.md updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/fallback.py
+++ b/utils/fallback.py
@@ -1,0 +1,51 @@
+"""Utility functions to run agents with retry and skip support."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict
+
+# Type alias for agent callable
+default_input_type = Dict[str, Any]
+AgentCallable = Callable[[default_input_type], default_input_type]
+
+
+def run_with_retry(
+    agent: AgentCallable,
+    payload: default_input_type,
+    *,
+    retries: int = 3,
+    delay: float = 1.0,
+    skip_on_fail: bool = True,
+) -> default_input_type:
+    """Run an agent with retry logic.
+
+    Args:
+        agent: Callable that accepts a dictionary and returns a dictionary.
+        payload: Input payload for the agent.
+        retries: Number of attempts before giving up.
+        delay: Delay in seconds between attempts.
+        skip_on_fail: If True, return a skipped result when all retries fail
+            instead of raising the exception.
+
+    Returns:
+        Dictionary result from the agent or skipped result.
+    """
+
+    attempt = 0
+    last_exc: Exception | None = None
+    while attempt < retries:
+        attempt += 1
+        try:
+            return agent(payload)
+        except Exception as exc:  # noqa: PERF203 - allow broad exception for agent errors
+            last_exc = exc
+            print(f"⚠️  {agent.__name__} failed on attempt {attempt}/{retries}: {exc}")
+            if attempt < retries:
+                time.sleep(delay)
+
+    if skip_on_fail:
+        print(f"⏭️  Skipping {agent.__name__} after {retries} failed attempts")
+        return {"status": "skipped", "error": str(last_exc) if last_exc else "unknown"}
+
+    raise last_exc if last_exc else RuntimeError("Unknown agent error")


### PR DESCRIPTION
## Summary
- add fallback util for retry logic
- script to publish build artifacts to S3
- tool to generate CHANGELOG from agent journal
- provide requirements-full.txt for CI environments

## Testing
- `pre-commit run --files utils/fallback.py ci_publish.py tools/gen_changelog.py requirements-full.txt`

------
https://chatgpt.com/codex/tasks/task_e_686befc1779883209ef33117552c9716