### PR TITLE
Implement assets QC HTML report

### DIFF
--- a/ci_assets.py
+++ b/ci_assets.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from utils.asset_catalog import catalog_assets
 from utils.asset_generator import generate_from_specs
 from utils.asset_qc import run_qc
+from tools.gen_assets_report import generate_assets_report
 
 
 REQUESTS_FILE = Path(os.getenv("ASSET_REQUESTS", "asset_requests.json"))
@@ -29,8 +30,10 @@ def main() -> None:
 
     reports = Path(os.getenv("CI_REPORTS_DIR", "ci_reports"))
     reports.mkdir(exist_ok=True)
+    generate_assets_report(out_dir=str(reports))
     out_path = reports / "ci_assets.json"
-    out_path.write_text(json.dumps(generated, indent=2, ensure_ascii=False), encoding="utf-8")
+    out_text = json.dumps(generated, indent=2, ensure_ascii=False)
+    out_path.write_text(out_text, encoding="utf-8")
     print(json.dumps(generated, indent=2, ensure_ascii=False))
 
 

--- a/ci_monitor.py
+++ b/ci_monitor.py
@@ -48,14 +48,24 @@ class Handler(BaseHTTPRequestHandler):
             for p in REPORTS_DIR.iterdir():
                 if p.suffix in {".zip", ".apk"}:
                     artifacts.append(str(p))
-        summary = str(REPORTS_DIR / "summary.html") if (REPORTS_DIR / "summary.html").exists() else ""
-        changelog = str(Path("CHANGELOG.md")) if Path("CHANGELOG.md").exists() else ""
-        return {"artifacts": artifacts, "summary": summary, "changelog": changelog}
+        summary = str(REPORTS_DIR / "summary.html")
+        changelog_path = Path("CHANGELOG.md")
+        changelog = (
+            changelog_path.read_text(encoding="utf-8")
+            if changelog_path.exists()
+            else ""
+        )
+        return {
+            "artifacts": artifacts,
+            "summary": summary,
+            "changelog": changelog,
+        }
 
 
 def run(server_address: tuple[str, int] = ("", PORT)) -> None:
     httpd = HTTPServer(server_address, Handler)
-    print(f"CI monitor running on http://{server_address[0] or 'localhost'}:{server_address[1]}")
+    host = server_address[0] or "localhost"
+    print(f"CI monitor running on http://{host}:{server_address[1]}")
     httpd.serve_forever()
 
 

--- a/templates/assets_report.html.j2
+++ b/templates/assets_report.html.j2
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Assets QC Report</title>
+<style>
+  body { font-family: Arial, sans-serif; }
+  table { border-collapse: collapse; }
+  th, td { border: 1px solid #ccc; padding: 4px 8px; }
+  .ok { background-color: #c8e6c9; }
+  .warning { background-color: #fff9c4; }
+  .error { background-color: #ffcdd2; }
+</style>
+</head>
+<body>
+<h1>Assets QC Report</h1>
+<table>
+<tr>
+  <th>Имя ассета</th>
+  <th>Путь</th>
+  <th>Количество полигонов</th>
+  <th>Макс. размер текстуры</th>
+  <th>QC статус</th>
+</tr>
+{% for a in assets %}
+<tr class="{{ a.status|lower }}">
+  <td>{{ a.name }}</td>
+  <td>{{ a.path }}</td>
+  <td>{{ a.polygons }}</td>
+  <td>{{ a.texture }}</td>
+  <td>{{ a.status }}</td>
+</tr>
+{% endfor %}
+</table>
+<h2>Metadata</h2>
+<ul>
+  <li>Дата: {{ metadata.date }}</li>
+  <li>Commit: {{ metadata.git_commit }}</li>
+  <li>Пользователь: {{ metadata.user }}</li>
+</ul>
+</body>
+</html>

--- a/tools/gen_assets_report.py
+++ b/tools/gen_assets_report.py
@@ -1,0 +1,94 @@
+"""Generate HTML QC report for assets."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from jinja2 import Environment, FileSystemLoader
+from utils.asset_qc import (
+    _check_texture,
+    _count_obj_polygons,
+    MAX_TEXTURE_RESOLUTION,
+)
+
+TEMPLATE_DIR = Path("templates")
+TEMPLATE_NAME = "assets_report.html.j2"
+QC_JSON = Path("asset_qc.json")
+
+
+def _load_issues() -> Dict[str, List[str]]:
+    issues: Dict[str, List[str]] = {}
+    if not QC_JSON.exists():
+        return issues
+    data = json.loads(QC_JSON.read_text(encoding="utf-8"))
+    for item in data:
+        asset = item.get("asset", "")
+        issue = item.get("issue", "")
+        issues.setdefault(asset, []).append(issue)
+    return issues
+
+
+def _render(assets: List[Dict[str, str]], metadata: Dict[str, str]) -> str:
+    env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)))
+    template = env.get_template(TEMPLATE_NAME)
+    return template.render(assets=assets, metadata=metadata)
+
+
+def generate_assets_report(
+    asset_dir: str = "Assets",
+    out_dir: str = "ci_reports",
+) -> Path:
+    """Create assets_report.html summarizing QC results."""
+    issue_map = _load_issues()
+    entries: List[Dict[str, str]] = []
+    for root, _dirs, files in os.walk(asset_dir):
+        for name in files:
+            path = Path(root) / name
+            rel_path = path.as_posix()
+            ext = path.suffix.lower()
+            polygons = "-"
+            texture = "-"
+            if ext == ".obj":
+                polygons = str(_count_obj_polygons(path))
+            elif ext in {".png", ".jpg", ".jpeg"}:
+                _ok, w, h = _check_texture(path, MAX_TEXTURE_RESOLUTION)
+                texture = f"{w}x{h}"
+            status = "OK" if rel_path not in issue_map else "Error"
+            entries.append(
+                {
+                    "name": name,
+                    "path": rel_path,
+                    "polygons": polygons,
+                    "texture": texture,
+                    "status": status,
+                }
+            )
+    metadata = {
+        "date": datetime.utcnow().isoformat(),
+        "git_commit": subprocess.check_output([
+            "git",
+            "rev-parse",
+            "HEAD",
+        ]).decode().strip(),
+        "user": os.getenv("USER", "unknown"),
+    }
+    html = _render(entries, metadata)
+    out_directory = Path(out_dir)
+    out_directory.mkdir(exist_ok=True)
+    out_path = out_directory / "assets_report.html"
+    out_path.write_text(html, encoding="utf-8")
+    return out_path
+
+
+def main() -> None:
+    path = generate_assets_report()
+    print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gen_summary.py
+++ b/tools/gen_summary.py
@@ -79,11 +79,24 @@ def generate_summary(
     """Create summary.html from given data."""
     metadata = {
         "date": datetime.utcnow().isoformat(),
-        "git_commit": subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip(),
+        "git_commit": subprocess.check_output([
+            "git",
+            "rev-parse",
+            "HEAD",
+        ]).decode().strip(),
         "user": os.getenv("USER", "unknown"),
     }
     changelog_path = Path("CHANGELOG.md")
-    changelog = changelog_path.read_text(encoding="utf-8") if changelog_path.exists() else ""
+    changelog = (
+        changelog_path.read_text(encoding="utf-8")
+        if changelog_path.exists()
+        else ""
+    )
+
+    asset_report = Path(out_dir) / "assets_report.html"
+    if asset_report.exists():
+        artifact_urls = list(artifact_urls) + [asset_report.as_posix()]
+
     html = _render(artifact_urls, agent_results, metadata, changelog)
     out_directory = Path(out_dir)
     out_directory.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- generate assets_report.html via new tool
- update ci_assets.py to produce report
- link asset report in summary html
- tweak notify flow to satisfy tests
- adjust CI monitor summary output

## Testing
- `flake8 ci_assets.py ci_monitor.py notify.py tools/gen_summary.py tools/gen_assets_report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bff716df08320bf8023393a67db64