### PR TITLE
Remove trailing blank lines

### DIFF
--- a/agents/creative/art_mood.py
+++ b/agents/creative/art_mood.py
@@ -16,4 +16,3 @@ def run(input: dict) -> dict:
     result = {"moodboard": str(path)}
     log_trace("ArtMoodAgent", "run", input, result)
     return result
-

--- a/agents/creative/creative_orchestrator.py
+++ b/agents/creative/creative_orchestrator.py
@@ -21,4 +21,3 @@ def run(input: dict) -> dict:
     Path("idea_spec.json").write_text(json.dumps(spec, indent=2, ensure_ascii=False), encoding="utf-8")
     log_trace("CreativeOrchestrator", "run", input, spec)
     return spec
-

--- a/agents/creative/game_designer.py
+++ b/agents/creative/game_designer.py
@@ -18,4 +18,3 @@ def run(input: dict) -> dict:
     result = {"core_loop": core_loop, "file": "core_loop.md"}
     log_trace("CreativeGameDesigner", "run", input, result)
     return result
-

--- a/agents/creative/lore_keeper.py
+++ b/agents/creative/lore_keeper.py
@@ -33,4 +33,3 @@ def run(input: dict) -> dict:
     result = {"lorebook": str(lore_path)}
     log_trace("LoreKeeperAgent", "run", input, result)
     return result
-

--- a/agents/creative/narrative_designer.py
+++ b/agents/creative/narrative_designer.py
@@ -25,4 +25,3 @@ def run(input: dict) -> dict:
     result = {"scene": str(scene_path)}
     log_trace("NarrativeDesignerAgent", "run", input, result)
     return result
-

--- a/agents/tech/architect_agent.py
+++ b/agents/tech/architect_agent.py
@@ -39,4 +39,3 @@ def run(input: dict) -> dict:
     log_trace("ArchitectAgent", "run", input, result)
     agent_memory.write("architecture", result)
     return result
-

--- a/agents/tech/build_agent.py
+++ b/agents/tech/build_agent.py
@@ -38,4 +38,3 @@ def run(input: dict) -> dict:
     result = {"target": target, "artifact": artifact, "status": status}
     log_trace("BuildAgent", "run", input, result)
     return result
-

--- a/agents/tech/coder.py
+++ b/agents/tech/coder.py
@@ -44,4 +44,3 @@ def coder(task_spec):
 def run(task_spec):
     """Public wrapper used by the orchestrator."""
     return coder(task_spec)
-

--- a/agents/tech/game_designer.py
+++ b/agents/tech/game_designer.py
@@ -22,4 +22,3 @@ def run(input: dict) -> dict:
     log_trace("GameDesignerAgent", "run", input, result)
     agent_memory.write("feature_description", result)
     return result
-

--- a/agents/tech/project_manager.py
+++ b/agents/tech/project_manager.py
@@ -37,4 +37,3 @@ def run(feature: dict) -> dict:
     log_trace("ProjectManagerAgent", "run", feature, result)
     agent_memory.write("tasks", result)
     return result
-

--- a/agents/tech/refactor_agent.py
+++ b/agents/tech/refactor_agent.py
@@ -40,4 +40,3 @@ def run(input: dict) -> dict:
     }
     log_trace("RefactorAgent", "run", input, result)
     return result
-

--- a/agents/tech/review_agent.py
+++ b/agents/tech/review_agent.py
@@ -58,4 +58,3 @@ def run(_: dict | None = None) -> dict:
     result = {"status": status, "report": "review_report.json"}
     log_trace("ReviewAgent", "run", None, result)
     return result
-

--- a/agents/tech/scene_builder_agent.py
+++ b/agents/tech/scene_builder_agent.py
@@ -30,4 +30,3 @@ def run(input: dict) -> dict:
     log_trace("SceneBuilderAgent", "run", input, result)
     agent_memory.write("scene", result)
     return result
-

--- a/agents/tech/tester.py
+++ b/agents/tech/tester.py
@@ -120,4 +120,3 @@ def run(task_spec) -> dict:
 
 if __name__ == "__main__":
     print(json.dumps(tester({}), indent=2, ensure_ascii=False))
-

--- a/utils/agent_journal.py
+++ b/utils/agent_journal.py
@@ -34,4 +34,3 @@ def log_trace(agent: str, stage: str, data_in: Any, data_out: Any) -> None:
     }
     with TRACE_PATH.open("a", encoding="utf-8") as f:
         f.write(f"{json.dumps(entry, ensure_ascii=False)}\n")
-


### PR DESCRIPTION
## Summary
- fix flake8 W391 warnings by removing blank lines at end of files

## Testing
- `flake8 agents utils --max-line-length=120`
- `pre-commit run --files agents/creative/art_mood.py agents/creative/creative_orchestrator.py agents/creative/game_designer.py agents/creative/lore_keeper.py agents/creative/narrative_designer.py agents/tech/architect_agent.py agents/tech/build_agent.py agents/tech/coder.py agents/tech/game_designer.py agents/tech/project_manager.py agents/tech/refactor_agent.py agents/tech/review_agent.py agents/tech/scene_builder_agent.py agents/tech/tester.py utils/agent_journal.py`

------
https://chatgpt.com/codex/tasks/task_e_686c0a0b03ec83209091813158fd9e68