### PR TITLE
Add CI overview dashboard generation

### DIFF
--- a/dashboard_api.py
+++ b/dashboard_api.py
@@ -101,6 +101,8 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json(_load_trace_stats())
         elif self.path == "/agent-stats":
             self._send_html_file(Path("ci_reports") / "agent_stats.html")
+        elif self.path == "/overview":
+            self._send_html_file(Path("ci_reports") / "ci_overview.html")
         else:
             self.send_response(404)
             self.end_headers()

--- a/run_all.py
+++ b/run_all.py
@@ -23,6 +23,7 @@ from tools.gen_changelog import main as gen_changelog
 from tools.gen_summary import generate_summary
 from tools.gen_multifeature_summary import generate_multifeature_summary
 from tools.gen_agent_stats import generate_agent_stats
+from tools.gen_ci_overview import generate_ci_overview
 from utils.agent_journal import read_entries
 from utils.pipeline_config import load_config
 
@@ -171,6 +172,8 @@ def run_once(optimize: bool = False) -> tuple[Path, dict]:
     agent_results["Publish"] = publish_status
     summary_path = generate_summary(urls, agent_results, out_dir=str(reports))
     print(f"Summary HTML: {summary_path}")
+
+    generate_ci_overview(out_dir=str(reports))
 
     notify_all(str(summary_path), "CHANGELOG.md", urls)
 

--- a/templates/ci_overview.html.j2
+++ b/templates/ci_overview.html.j2
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>CI Overview</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 4px 8px; }
+    .in_progress { background-color: #fff9c4; }
+    .done { background-color: #c8e6c9; }
+    .error { background-color: #ffcdd2; }
+  </style>
+  <script>
+    function toTime(val) {
+      if (!val) return '';
+      if (typeof val === 'number') {
+        return new Date(val * 1000).toLocaleTimeString();
+      }
+      return new Date(val).toLocaleTimeString();
+    }
+
+    const icons = {
+      in_progress: '🟡',
+      done: '🟢',
+      error: '🔴'
+    };
+
+    async function refreshProgress() {
+      const resp = await fetch('{{ monitor_url }}');
+      const json = await resp.json();
+      let items = json.features;
+      if (!items) {
+        items = Object.entries(json).map(([feature, info]) => ({ feature, ...info }));
+      }
+      const tbody = document.getElementById('progress-body');
+      tbody.innerHTML = '';
+      for (const f of items) {
+        const tr = document.createElement('tr');
+        tr.className = f.status;
+        const icon = icons[f.status] || '';
+        tr.innerHTML = `<td>${f.feature || f.name}</td>`+
+                       `<td>${icon} ${f.status}</td>`+
+                       `<td>${toTime(f.started)}</td>`+
+                       `<td>${toTime(f.ended)}</td>`;
+        tbody.appendChild(tr);
+      }
+    }
+
+    setInterval(refreshProgress, 10000);
+    window.onload = refreshProgress;
+  </script>
+</head>
+<body>
+<h1>CI Overview</h1>
+<button onclick="location.reload()">Обновить</button>
+
+<h2>Pipeline Progress</h2>
+<table>
+<tr><th>Feature</th><th>Status</th><th>Start</th><th>End</th></tr>
+<tbody id="progress-body"></tbody>
+</table>
+
+<h2>Agent Statistics</h2>
+<table>
+<tr>
+  <th>Agent</th>
+  <th>Calls</th>
+  <th>Auto-fixes</th>
+  <th>Successes</th>
+  <th>Failures</th>
+  <th>Avg time (s)</th>
+</tr>
+{% for s in stats %}
+<tr>
+  <td>{{ s.agent }}</td>
+  <td>{{ s.calls }}</td>
+  <td>{{ s.auto_fixes }}</td>
+  <td>{{ s.success }}</td>
+  <td>{{ s.fail }}</td>
+  <td>{{ s.avg_time if s.avg_time is not none else '' }}</td>
+</tr>
+{% endfor %}
+</table>
+
+<h2>Pipeline Time</h2>
+<ul>
+  <li>Start: {{ metadata.start }}</li>
+  <li>End: {{ metadata.end }}</li>
+  <li>Generated: {{ metadata.generated }}</li>
+</ul>
+
+<h2>Reports</h2>
+<ul>
+{% for r in reports %}
+  <li><a href="{{ r }}">{{ r }}</a></li>
+{% endfor %}
+</ul>
+</body>
+</html>

--- a/tools/gen_ci_overview.py
+++ b/tools/gen_ci_overview.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Generate CI overview HTML page."""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from jinja2 import Environment, FileSystemLoader
+
+import tools.gen_agent_stats as gen_stats
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+TEMPLATE_DIR = ROOT_DIR / "templates"
+TEMPLATE_NAME = "ci_overview.html.j2"
+STATUS_FILE = ROOT_DIR / "pipeline_status.json"
+
+
+def _load_features(status_path: Path = STATUS_FILE) -> List[Dict[str, Any]]:
+    features: List[Dict[str, Any]] = []
+    if status_path.exists():
+        try:
+            data = json.loads(status_path.read_text(encoding="utf-8"))
+            for name, info in data.get("features", {}).items():
+                features.append(
+                    {
+                        "name": name,
+                        "status": info.get("status"),
+                        "started": info.get("started"),
+                        "ended": info.get("ended"),
+                        "summary": info.get("summary_path"),
+                    }
+                )
+        except Exception:
+            pass
+    return features
+
+
+def _pipeline_times(features: List[Dict[str, Any]]) -> tuple[str | None, str | None]:
+    starts = [f.get("started") for f in features if f.get("started")]
+    ends = [f.get("ended") for f in features if f.get("ended")]
+    start = min(starts) if starts else None
+    end = max(ends) if ends else None
+    if isinstance(start, float):
+        start = datetime.fromtimestamp(start).isoformat()
+    if isinstance(end, float):
+        end = datetime.fromtimestamp(end).isoformat()
+    return start, end
+
+
+def _collect_agent_stats(
+    journal: Path | None = None,
+    memory: Path | None = None,
+    trace: Path | None = None,
+) -> List[Dict[str, Any]]:
+    journal = journal or gen_stats.JOURNAL_PATH
+    memory = memory or gen_stats.MEMORY_PATH
+    trace = trace or gen_stats.TRACE_PATH
+    calls = gen_stats._parse_journal(journal)
+    success, fail, autofix = gen_stats._parse_memory(memory)
+    avg_time = gen_stats._parse_trace(trace)
+    agents = sorted(set(calls) | set(success) | set(fail) | set(autofix) | set(avg_time))
+    stats = [
+        {
+            "agent": a,
+            "calls": calls.get(a, 0),
+            "auto_fixes": autofix.get(a, 0),
+            "success": success.get(a, 0),
+            "fail": fail.get(a, 0),
+            "avg_time": avg_time.get(a),
+        }
+        for a in agents
+    ]
+    return stats
+
+
+def _list_reports(reports_dir: Path) -> List[str]:
+    links: List[str] = []
+    if reports_dir.exists():
+        for p in sorted(reports_dir.rglob("*")):
+            if p.suffix in {".html", ".md"}:
+                links.append(p.relative_to(reports_dir).as_posix())
+    return links
+
+
+def generate_ci_overview(out_dir: str = "ci_reports") -> Path:
+    """Create ci_overview.html in given directory."""
+    reports_dir = Path(out_dir)
+    features = _load_features()
+    start, end = _pipeline_times(features)
+    stats = _collect_agent_stats(
+        journal=gen_stats.JOURNAL_PATH,
+        memory=gen_stats.MEMORY_PATH,
+        trace=gen_stats.TRACE_PATH,
+    )
+    links = _list_reports(reports_dir)
+    metadata = {
+        "start": start,
+        "end": end,
+        "generated": datetime.utcnow().isoformat(),
+    }
+    env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)))
+    template = env.get_template(TEMPLATE_NAME)
+    monitor_port = os.getenv("MONITOR_PORT", "8002")
+    monitor_url = os.getenv("CI_STATUS_URL", f"http://localhost:{monitor_port}/ci-status")
+    html = template.render(stats=stats, reports=links, metadata=metadata, monitor_url=monitor_url)
+    reports_dir.mkdir(exist_ok=True)
+    out_path = reports_dir / "ci_overview.html"
+    out_path.write_text(html, encoding="utf-8")
+    return out_path
+
+
+if __name__ == "__main__":
+    path = generate_ci_overview()
+    print(path)

--- a/tools/test_gen_ci_overview.py
+++ b/tools/test_gen_ci_overview.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from tools.gen_ci_overview import generate_ci_overview
+import tools.gen_agent_stats as gen_stats
+
+
+def test_generate_ci_overview(tmp_path, monkeypatch):
+    status = {
+        "features": {
+            "feat": {
+                "status": "passed",
+                "started": 1.0,
+                "ended": 2.0,
+                "summary_path": "summary.html",
+            }
+        }
+    }
+    (tmp_path / "pipeline_status.json").write_text(json.dumps(status), encoding="utf-8")
+
+    journal = tmp_path / "agent_journal.log"
+    journal.write_text("2024-01-01T00:00:00 [CoderAgent] start\n", encoding="utf-8")
+
+    memory = {"learning_log": {"CoderAgent": [{"result": "success"}]}}
+    (tmp_path / "agent_memory.json").write_text(json.dumps(memory), encoding="utf-8")
+
+    trace = tmp_path / "agent_trace.log"
+    entry = {"agent": "CoderAgent", "start_time": "2024-01-01T00:00:00", "end_time": "2024-01-01T00:00:01"}
+    trace.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+
+    reports = tmp_path / "ci_reports"
+    reports.mkdir()
+    (reports / "summary.html").write_text("<html></html>", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gen_stats, "JOURNAL_PATH", journal)
+    monkeypatch.setattr(gen_stats, "MEMORY_PATH", tmp_path / "agent_memory.json")
+    monkeypatch.setattr(gen_stats, "TRACE_PATH", trace)
+    out = generate_ci_overview(out_dir=reports)
+    assert out.exists()
+    html = out.read_text(encoding="utf-8")
+    assert "CI Overview" in html
+    assert "CoderAgent" in html


### PR DESCRIPTION
## Summary
- generate a unified CI overview page with Jinja2
- include progress from `/ci-status`, agent statistics and report links
- expose new `/overview` endpoint in `dashboard_api.py`
- call generator from `run_all.py`
- provide test for the generator

## Testing
- `pip install jinja2`
- `PYTHONPATH=. pytest -q tools/test_gen_ci_overview.py tools/test_gen_agent_stats.py tools/test_gen_learning_report.py tools/test_gen_trace_report.py`

------
https://chatgpt.com/codex/tasks/task_e_686c291467688320a873c3b03d838592