### PR TITLE
Implement MetaAgent analysis

### DIFF
--- a/meta_agent.py
+++ b/meta_agent.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+"""MetaAgent analyzes CI data and produces optimization insights."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from jinja2 import Environment, FileSystemLoader
+
+ROOT_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = ROOT_DIR / "templates"
+TEMPLATE_NAME = "meta_insights.md.j2"
+
+
+class MetaAgent:
+    """Analyze pipeline data and generate meta_insights.md."""
+
+    def __init__(
+        self,
+        out_dir: str = "ci_reports",
+        memory_path: Path | None = None,
+        journal_path: Path | None = None,
+        trace_path: Path | None = None,
+        feedback_path: Path | None = None,
+    ) -> None:
+        self.out_dir = Path(out_dir)
+        self.memory_path = memory_path or Path("agent_memory.json")
+        self.journal_path = journal_path or Path("agent_journal.log")
+        # prefer jsonl/log if exists, else html
+        self.trace_path = trace_path or Path("trace_report.jsonl")
+        if not self.trace_path.exists():
+            self.trace_path = Path("agent_trace.log")
+        self.feedback_path = feedback_path or Path("user_feedback_report.md")
+
+    # internal helpers
+    def _load_memory(self) -> Dict[str, List[dict]]:
+        if not self.memory_path.exists():
+            return {}
+        try:
+            data = json.loads(self.memory_path.read_text(encoding="utf-8"))
+            return data.get("learning_log", {})
+        except Exception:
+            return {}
+
+    def _parse_journal(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        if not self.journal_path.exists():
+            return counts
+        for line in self.journal_path.read_text(encoding="utf-8").splitlines():
+            if "[" in line and "]" in line:
+                agent = line.split("[", 1)[1].split("]", 1)[0]
+                counts[agent] = counts.get(agent, 0) + 1
+        return counts
+
+    def _parse_trace(self) -> Dict[str, Any]:
+        durations: Dict[str, float] = {}
+        counts: Dict[str, int] = {}
+        if not self.trace_path.exists():
+            return {}
+        for line in self.trace_path.read_text(encoding="utf-8").splitlines():
+            try:
+                item = json.loads(line)
+            except Exception:
+                continue
+            agent = item.get("agent")
+            start = item.get("start_time")
+            end = item.get("end_time")
+            if not agent or not start or not end:
+                continue
+            try:
+                s_dt = datetime.fromisoformat(start)
+                e_dt = datetime.fromisoformat(end)
+            except Exception:
+                continue
+            dur = (e_dt - s_dt).total_seconds()
+            durations[agent] = durations.get(agent, 0.0) + dur
+            counts[agent] = counts.get(agent, 0) + 1
+        result = {
+            a: {
+                "avg_time": round(durations[a] / counts[a], 2),
+                "calls": counts[a],
+            }
+            for a in durations
+        }
+        return result
+
+    def _parse_feedback(self) -> Dict[str, float]:
+        ratings: List[int] = []
+        if not self.feedback_path.exists():
+            return {"avg_rating": 0.0}
+        for line in self.feedback_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("|") and "|" in line[1:]:
+                parts = [p.strip() for p in line.strip().split("|") if p.strip()]
+                if len(parts) >= 2 and parts[0] != "Variant":
+                    try:
+                        ratings.append(int(parts[1]))
+                    except ValueError:
+                        continue
+        avg = sum(ratings) / len(ratings) if ratings else 0.0
+        return {"avg_rating": round(avg, 2)}
+
+    def _build_context(self) -> Dict[str, Any]:
+        log = self._load_memory()
+        journal = self._parse_journal()
+        trace = self._parse_trace()
+        feedback = self._parse_feedback()
+
+        failures: List[Dict[str, Any]] = []
+        autofix: List[Dict[str, Any]] = []
+
+        for agent, entries in log.items():
+            if agent.startswith("AutoFix:"):
+                base = agent.split("AutoFix:", 1)[1]
+                patterns: Dict[str, int] = {}
+                for e in entries:
+                    out = e.get("output")
+                    if out:
+                        patterns[out] = patterns.get(out, 0) + 1
+                repeated = sum(1 for c in patterns.values() if c > 1)
+                if repeated:
+                    autofix.append({"agent": base, "count": repeated})
+            else:
+                total = len(entries)
+                fail = sum(1 for e in entries if e.get("result") != "success")
+                if fail:
+                    failures.append(
+                        {
+                            "agent": agent,
+                            "fails": fail,
+                            "total": total,
+                            "rate": fail / total if total else 0.0,
+                        }
+                    )
+
+        failures.sort(key=lambda x: x["rate"], reverse=True)
+
+        performance = [
+            {
+                "agent": a,
+                "avg_time": trace[a]["avg_time"],
+                "calls": trace[a]["calls"],
+            }
+            for a in sorted(trace)
+        ]
+
+        return {
+            "failures": failures,
+            "autofix": autofix,
+            "performance": performance,
+            "quality": feedback,
+        }
+
+    def _render(self, context: Dict[str, Any]) -> str:
+        env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)))
+        template = env.get_template(TEMPLATE_NAME)
+        return template.render(**context)
+
+    def run(self) -> Dict[str, Any]:
+        """Generate meta insights markdown and return result info."""
+        context = self._build_context()
+        text = self._render(context)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = self.out_dir / "meta_insights.md"
+        out_path.write_text(text, encoding="utf-8")
+        return {"status": "success", "report": str(out_path)}
+
+
+if __name__ == "__main__":
+    print(MetaAgent().run())

--- a/run_all.py
+++ b/run_all.py
@@ -32,6 +32,7 @@ from tools.gen_changelog import main as gen_changelog
 from tools.gen_ci_overview import generate_ci_overview
 from tools.gen_multifeature_summary import generate_multifeature_summary
 from tools.gen_summary import generate_summary
+from meta_agent import MetaAgent
 from utils.agent_journal import read_entries
 from utils.backup_manager import restore_backup, save_backup
 from utils.pipeline_config import load_config
@@ -238,7 +239,19 @@ def run_once(optimize: bool = False, feature_name: str = "single") -> tuple[Path
         feedback_text = Path(feedback_result["report"]).read_text(encoding="utf-8")
     except Exception:
         pass
-    summary_path = generate_summary(urls, agent_results, feedback_text, out_dir=str(reports))
+    meta_text = ""
+    try:
+        meta_result = MetaAgent(out_dir=str(reports)).run()
+        meta_text = Path(meta_result["report"]).read_text(encoding="utf-8")
+    except Exception:
+        pass
+    summary_path = generate_summary(
+        urls,
+        agent_results,
+        feedback_text,
+        meta_insights=meta_text,
+        out_dir=str(reports),
+    )
     print(f"Summary HTML: {summary_path}")
 
     generate_ci_overview(out_dir=str(reports))

--- a/templates/meta_insights.md.j2
+++ b/templates/meta_insights.md.j2
@@ -1,0 +1,22 @@
+# Meta Insights
+
+{% if failures %}
+## Frequent Failures
+{% for f in failures %}- {{ f.agent }}: {{ f.fails }}/{{ f.total }} failures ({{ (f.rate * 100) | round(1) }}%)
+{% endfor %}
+{% endif %}
+
+{% if autofix %}
+## Repeated Auto-Fix Patterns
+{% for a in autofix %}- {{ a.agent }}: {{ a.count }} repeating patterns
+{% endfor %}
+{% endif %}
+
+## Agent Performance
+{% for p in performance %}- {{ p.agent }}: avg {{ p.avg_time }}s over {{ p.calls }} calls
+{% endfor %}
+
+{% if quality.avg_rating %}
+## Generation Quality
+- Average user rating: {{ quality.avg_rating }}
+{% endif %}

--- a/tools/gen_summary.py
+++ b/tools/gen_summary.py
@@ -49,6 +49,9 @@ TEMPLATE = """<!DOCTYPE html>
 <h2>User Feedback</h2>
 <pre>{{ feedback }}</pre>
 
+<h2>Meta Insights</h2>
+<pre>{{ meta }}</pre>
+
 <h2>Metadata</h2>
 <ul>
   <li>Date: {{ metadata.date }}</li>
@@ -67,6 +70,7 @@ def _render(
     metadata: dict[str, str],
     changelog: str,
     feedback: str,
+    meta: str = "",
 ) -> str:
     env = Environment()
     template = env.from_string(TEMPLATE)
@@ -76,6 +80,7 @@ def _render(
         metadata=metadata,
         changelog=changelog,
         feedback=feedback,
+        meta=meta,
     )
 
 
@@ -83,6 +88,7 @@ def generate_summary(
     artifact_urls: list[str],
     agent_results: dict[str, str],
     feedback: str = "",
+    meta_insights: str = "",
     out_dir: str = "ci_reports",
 ) -> Path:
     """Create summary.html from given data."""
@@ -106,7 +112,9 @@ def generate_summary(
     if asset_report.exists():
         artifact_urls = list(artifact_urls) + [asset_report.as_posix()]
 
-    html = _render(artifact_urls, agent_results, metadata, changelog, feedback)
+    html = _render(
+        artifact_urls, agent_results, metadata, changelog, feedback, meta_insights
+    )
     out_directory = Path(out_dir)
     out_directory.mkdir(exist_ok=True)
     out_path = out_directory / "summary.html"
@@ -118,7 +126,8 @@ def main() -> None:
     urls = json.loads(os.getenv("SUMMARY_ARTIFACTS", "[]"))
     agents = json.loads(os.getenv("SUMMARY_AGENTS", "{}"))
     feedback = os.getenv("SUMMARY_FEEDBACK", "")
-    path = generate_summary(urls, agents, feedback)
+    meta = os.getenv("SUMMARY_META", "")
+    path = generate_summary(urls, agents, feedback, meta_insights=meta)
     print(path)
 
 

--- a/tools/test_meta_agent.py
+++ b/tools/test_meta_agent.py
@@ -1,0 +1,57 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from meta_agent import MetaAgent
+
+
+def test_meta_agent(tmp_path, monkeypatch):
+    # prepare sample files
+    mem = {
+        "learning_log": {
+            "CoderAgent": [
+                {"result": "error"},
+                {"result": "success"},
+                {"result": "error"},
+            ],
+            "AutoFix:CoderAgent": [
+                {"output": "fix1"},
+                {"output": "fix1"},
+                {"output": "fix2"},
+            ],
+        }
+    }
+    mem_file = tmp_path / "agent_memory.json"
+    mem_file.write_text(json.dumps(mem), encoding="utf-8")
+
+    journal = tmp_path / "agent_journal.log"
+    journal.write_text("2024-01-01 [CoderAgent] start\n", encoding="utf-8")
+
+    trace = tmp_path / "trace_report.jsonl"
+    entries = [
+        {
+            "agent": "CoderAgent",
+            "start_time": "2024-01-01T00:00:00",
+            "end_time": "2024-01-01T00:00:02",
+        }
+    ]
+    with trace.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+    feedback = tmp_path / "user_feedback_report.md"
+    feedback.write_text(
+        "# User Feedback Report\n\n| Variant | Rating | Comment | Reason |\n| A | 4 | ok | good |\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    agent = MetaAgent(out_dir=str(tmp_path))
+    res = agent.run()
+    assert res["status"] == "success"
+    report = tmp_path / "meta_insights.md"
+    assert report.exists()
+    text = report.read_text(encoding="utf-8")
+    assert "CoderAgent" in text


### PR DESCRIPTION
## Summary
- add `MetaAgent` to analyze logs and generate `meta_insights.md`
- expose meta insights in HTML summary
- call `MetaAgent` from `run_all.py`
- provide Jinja template for insights
- add unit test for MetaAgent

## Testing
- `pytest tools/test_meta_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686c4af92a088320bfefe768038df396