### PR TITLE
Add Windows installer scripts

### DIFF
--- a/ai_unity_studio_launcher.py
+++ b/ai_unity_studio_launcher.py
@@ -1,0 +1,19 @@
+"""Launch AI Unity Studio dashboard."""
+
+from pathlib import Path
+import subprocess
+import sys
+import webbrowser
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DASHBOARD = SCRIPT_DIR / "dashboard.py"
+
+
+def main() -> None:
+    proc = subprocess.Popen([sys.executable, str(DASHBOARD), "--serve"], cwd=SCRIPT_DIR)
+    webbrowser.open("http://localhost:8080/overview")
+    proc.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/env_setup.py
+++ b/env_setup.py
@@ -1,0 +1,41 @@
+"""Interactive .env configuration script."""
+
+from pathlib import Path
+import shutil
+
+ROOT_DIR = Path(__file__).resolve().parent
+ENV_EXAMPLE = ROOT_DIR / ".env.example"
+ENV_PATH = ROOT_DIR / ".env"
+
+
+def copy_env():
+    if not ENV_EXAMPLE.exists():
+        raise FileNotFoundError(".env.example not found")
+    if not ENV_PATH.exists():
+        shutil.copy(ENV_EXAMPLE, ENV_PATH)
+
+
+def update_value(lines: list[str], key: str, prompt: str) -> list[str]:
+    updated = []
+    for line in lines:
+        if line.startswith(f"{key}="):
+            current = line.split("=", 1)[1].strip()
+            value = input(f"{prompt} [{current}]: ").strip() or current
+            updated.append(f"{key}={value}")
+        else:
+            updated.append(line)
+    return updated
+
+
+def main() -> None:
+    copy_env()
+    lines = ENV_PATH.read_text().splitlines()
+    lines = update_value(lines, "PROJECT_PATH", "Enter PROJECT_PATH")
+    lines = update_value(lines, "UNITY_CLI", "Enter UNITY_CLI")
+    lines = update_value(lines, "OPENAI_API_KEY", "Enter OPENAI_API_KEY")
+    ENV_PATH.write_text("\n".join(lines) + "\n")
+    print("Updated .env")
+
+
+if __name__ == "__main__":
+    main()

--- a/install_python.ps1
+++ b/install_python.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+$pythonVersion = '3.10.11'
+$installDir = 'C:\\Python310'
+$installer = "python-$pythonVersion-amd64.exe"
+$url = "https://www.python.org/ftp/python/$pythonVersion/$installer"
+
+Write-Host "Downloading Python $pythonVersion..."
+Invoke-WebRequest -Uri $url -OutFile $installer
+
+Write-Host "Installing to $installDir..."
+Start-Process -FilePath $installer -ArgumentList "InstallAllUsers=1 TargetDir=$installDir PrependPath=1 Include_test=0" -Wait
+
+Remove-Item $installer
+Write-Host "Python installed"

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,22 @@
+@echo off
+setlocal
+
+where python >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    powershell -ExecutionPolicy Bypass -File install_python.ps1
+)
+
+python -c "import sys; exit(0) if sys.version_info >= (3,10) else exit(1)"
+if %ERRORLEVEL% NEQ 0 (
+    echo Python 3.10 or higher is required.
+    exit /b 1
+)
+
+python env_setup.py
+python -m pip install -r requirements-full.txt
+
+set SCRIPT_DIR=%~dp0
+powershell -ExecutionPolicy Bypass -Command "$s=(New-Object -COM WScript.Shell).CreateShortcut([Environment]::GetFolderPath('Desktop')+'\AI Unity Studio.lnk');$s.TargetPath='python';$s.Arguments='\"%SCRIPT_DIR%ai_unity_studio_launcher.py\"';$s.WorkingDirectory='%SCRIPT_DIR%';$s.Save()"
+
+python ai_unity_studio_launcher.py
+endlocal


### PR DESCRIPTION
## Summary
- add env_setup.py for interactive .env creation
- add ai_unity_studio_launcher.py to run the dashboard and open a browser
- add install_python.ps1 for Python 3.10 installation
- add setup.bat orchestrating installation on Windows

## Testing
- `python -m py_compile env_setup.py ai_unity_studio_launcher.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686cde6942148320b70681d80832d112