### PR TITLE
Add docstrings and fix naming

### DIFF
--- a/agents/creative/__init__.py
+++ b/agents/creative/__init__.py
@@ -1,3 +1,5 @@
+"""Import and re-export creative agents for convenience."""
+
 from importlib import import_module
 
 # Re-export creative agents for convenience

--- a/agents/creative/art_mood.py
+++ b/agents/creative/art_mood.py
@@ -1,12 +1,14 @@
+"""Generate mood board descriptions for game ideas."""
+
 from pathlib import Path
 
-from utils.llm import ask_mistral
 from utils.agent_journal import log_trace
+from utils.llm import ask_mistral
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Generate a textual mood board description."""
-    idea = input.get("text", "")
+    idea = data.get("text", "")
     prompt = "Create a one-paragraph mood board description for this game idea:\n" + idea
     description = ask_mistral(prompt)
     mood_dir = Path("moodboards")
@@ -14,5 +16,5 @@ def run(input: dict) -> dict:
     path = mood_dir / "mood.txt"
     path.write_text(description, encoding="utf-8")
     result = {"moodboard": str(path)}
-    log_trace("ArtMoodAgent", "run", input, result)
+    log_trace("ArtMoodAgent", "run", data, result)
     return result

--- a/agents/creative/creative_orchestrator.py
+++ b/agents/creative/creative_orchestrator.py
@@ -1,13 +1,16 @@
+"""Coordinate creative agents to build a full idea specification."""
+
 import json
 from pathlib import Path
 
-from . import art_mood, game_designer, lore_keeper, narrative_designer
 from utils.agent_journal import log_trace
 
+from . import art_mood, game_designer, lore_keeper, narrative_designer
 
-def run(input: dict) -> dict:
+
+def run(data: dict) -> dict:
     """Run the creative pipeline and store idea_spec.json."""
-    idea_text = input.get("text", "")
+    idea_text = data.get("text", "")
     gd = game_designer.run({"text": idea_text})
     scene = narrative_designer.run(gd)
     lore = lore_keeper.run(scene)
@@ -19,5 +22,5 @@ def run(input: dict) -> dict:
         "moodboard": mood.get("moodboard"),
     }
     Path("idea_spec.json").write_text(json.dumps(spec, indent=2, ensure_ascii=False), encoding="utf-8")
-    log_trace("CreativeOrchestrator", "run", input, spec)
+    log_trace("CreativeOrchestrator", "run", data, spec)
     return spec

--- a/agents/creative/game_designer.py
+++ b/agents/creative/game_designer.py
@@ -1,12 +1,14 @@
+"""Create concise core loop descriptions using a local LLM."""
+
 from pathlib import Path
 
-from utils.llm import ask_mistral
 from utils.agent_journal import log_trace
+from utils.llm import ask_mistral
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Generate a short core loop description using local LLM."""
-    idea = input.get("text", "").strip()
+    idea = data.get("text", "").strip()
     if not idea:
         return {"core_loop": ""}
     prompt = (
@@ -16,5 +18,5 @@ def run(input: dict) -> dict:
     core_loop = ask_mistral(prompt)
     Path("core_loop.md").write_text(core_loop, encoding="utf-8")
     result = {"core_loop": core_loop, "file": "core_loop.md"}
-    log_trace("CreativeGameDesigner", "run", input, result)
+    log_trace("CreativeGameDesigner", "run", data, result)
     return result

--- a/agents/creative/lore_keeper.py
+++ b/agents/creative/lore_keeper.py
@@ -1,13 +1,15 @@
+"""Maintain the lorebook based on generated narrative scenes."""
+
 import json
 from pathlib import Path
 
-from utils.llm import ask_mistral
 from utils.agent_journal import log_trace
+from utils.llm import ask_mistral
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Update lorebook with facts extracted from the narrative scene."""
-    scene_file = input.get("scene")
+    scene_file = data.get("scene")
     text = ""
     if scene_file and Path(scene_file).exists():
         text = Path(scene_file).read_text(encoding="utf-8")
@@ -31,5 +33,5 @@ def run(input: dict) -> dict:
         lore[str(len(lore))] = reply
     lore_path.write_text(json.dumps(lore, indent=2, ensure_ascii=False), encoding="utf-8")
     result = {"lorebook": str(lore_path)}
-    log_trace("LoreKeeperAgent", "run", input, result)
+    log_trace("LoreKeeperAgent", "run", data, result)
     return result

--- a/agents/creative/lore_validator.py
+++ b/agents/creative/lore_validator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Validate generated content against the existing lore."""
+
 import json
 import re
 from pathlib import Path

--- a/agents/creative/narrative_designer.py
+++ b/agents/creative/narrative_designer.py
@@ -1,13 +1,15 @@
+"""Generate short narrative scenes from the core gameplay loop."""
+
 import json
 from pathlib import Path
 
-from utils.llm import ask_mistral
 from utils.agent_journal import log_trace
+from utils.llm import ask_mistral
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Create a simple narrative event JSON based on core loop."""
-    core_loop = input.get("core_loop", "")
+    core_loop = data.get("core_loop", "")
     prompt = (
         "Create a short intro scene for the following game core loop as JSON with "
         "fields 'scene' and 'dialogue' (list of lines).\n" + core_loop
@@ -23,5 +25,5 @@ def run(input: dict) -> dict:
         scene = {"scene": "intro", "dialogue": [reply]}
         scene_path.write_text(json.dumps(scene, indent=2, ensure_ascii=False), encoding="utf-8")
     result = {"scene": str(scene_path)}
-    log_trace("NarrativeDesignerAgent", "run", input, result)
+    log_trace("NarrativeDesignerAgent", "run", data, result)
     return result

--- a/agents/tech/architect_agent.py
+++ b/agents/tech/architect_agent.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
+"""Plan script locations and namespaces for generated features."""
+
 import json
 from pathlib import Path
 
+import agent_memory
 import config
 from utils.agent_journal import log_trace
-import agent_memory
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Determine script path/namespace and ensure asmdef exists."""
-    if not input:
-        input = agent_memory.read("tasks") or agent_memory.read("feature_description") or {}
-    feature = input.get("feature") or input.get("task") or (input.get("tasks") or [{}])[0].get("feature")
+    if not data:
+        data = agent_memory.read("tasks") or agent_memory.read("feature_description") or {}
+    feature = data.get("feature") or data.get("task") or (data.get("tasks") or [{}])[0].get("feature")
 
     if isinstance(feature, dict):
         feature = feature.get("feature")
@@ -36,6 +38,6 @@ def run(input: dict) -> dict:
         "namespace": "AIUnityStudio.Generated",
         "asmdef": asmdef_file.stem,
     }
-    log_trace("ArchitectAgent", "run", input, result)
+    log_trace("ArchitectAgent", "run", data, result)
     agent_memory.write("architecture", result)
     return result

--- a/agents/tech/build_agent.py
+++ b/agents/tech/build_agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Build the Unity project for a given target."""
+
 import shutil
 import subprocess
 from pathlib import Path
@@ -8,9 +10,9 @@ import config
 from utils.agent_journal import log_action, log_trace
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Build the project for a given target using Unity CLI."""
-    target = input.get("target", "WebGL")
+    target = data.get("target", "WebGL")
     out_dir = Path("Build") / target
     log_action("BuildAgent", f"start {target}")
     cmd = [
@@ -36,5 +38,5 @@ def run(input: dict) -> dict:
     log_action("BuildAgent", status)
 
     result = {"target": target, "artifact": artifact, "status": status}
-    log_trace("BuildAgent", "run", input, result)
+    log_trace("BuildAgent", "run", data, result)
     return result

--- a/agents/tech/coder.py
+++ b/agents/tech/coder.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+"""Utilities for generating C# code using a local LLM."""
+
 from pathlib import Path
 
+import agent_memory
+from utils.agent_journal import log_trace
 from utils.llm import ask_mistral
 from utils.test_generation import generate_test_files
-from utils.agent_journal import log_trace
-import agent_memory
 
 
 def coder(task_spec):

--- a/agents/tech/feature_inspector.py
+++ b/agents/tech/feature_inspector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Analyze assets and features to maintain an index."""
+
 import json
 from pathlib import Path
 from typing import Any, Dict, List

--- a/agents/tech/orchestrator.py
+++ b/agents/tech/orchestrator.py
@@ -1,3 +1,5 @@
+"""Entry point for coordinating all technical agents."""
+
 import json
 import sys
 

--- a/agents/tech/refactor_agent.py
+++ b/agents/tech/refactor_agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Run static analysis and code formatting for the project."""
+
 import subprocess
 from pathlib import Path
 
@@ -7,7 +9,7 @@ import config
 from utils.agent_journal import log_action, log_trace
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Run Roslyn analyzers and dotnet format, saving report to refactor_report.txt."""
 
     log_action("RefactorAgent", "start")
@@ -38,5 +40,5 @@ def run(input: dict) -> dict:
         "dead_code": dead_code,
         "report": str(report_path),
     }
-    log_trace("RefactorAgent", "run", input, result)
+    log_trace("RefactorAgent", "run", data, result)
     return result

--- a/agents/tech/review_agent.py
+++ b/agents/tech/review_agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Run flake8, dotnet format, and Roslyn checks for code quality."""
+
 import json
 import subprocess
 from pathlib import Path

--- a/agents/tech/scene_builder_agent.py
+++ b/agents/tech/scene_builder_agent.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
+"""Generate simple scene files corresponding to generated scripts."""
+
 import json
 from pathlib import Path
 
-from utils.agent_journal import log_trace
 import agent_memory
+from utils.agent_journal import log_trace
 
 
-def run(input: dict) -> dict:
+def run(data: dict) -> dict:
     """Generate a simple scene description tied to the generated script."""
 
-    if not input:
-        input = agent_memory.read("architecture") or {}
-    script_path = input.get("path", "Generated/Helper.cs")
+    if not data:
+        data = agent_memory.read("architecture") or {}
+    script_path = data.get("path", "Generated/Helper.cs")
     scene_dir = Path("Assets/Scenes/Generated")
     scene_dir.mkdir(parents=True, exist_ok=True)
 
@@ -27,6 +29,6 @@ def run(input: dict) -> dict:
         "scene": str(json_path),
         "objects": scene_data["monobehaviours"],
     }
-    log_trace("SceneBuilderAgent", "run", input, result)
+    log_trace("SceneBuilderAgent", "run", data, result)
     agent_memory.write("scene", result)
     return result

--- a/agents/tech/team_lead.py
+++ b/agents/tech/team_lead.py
@@ -1,6 +1,8 @@
 # agents/tech/team_lead.py
 from __future__ import annotations
 
+"""Persist metrics and logs for each pipeline execution."""
+
 import json
 from datetime import datetime
 from pathlib import Path

--- a/agents/tech/tester.py
+++ b/agents/tech/tester.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Utilities to build and run Unity tests via the CLI."""
+
 import json
 import subprocess
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary
- add missing module docstrings and sort imports
- rename `input` parameters to `data` to avoid built-in shadowing
- run formatting and tests

## Testing
- `pre-commit run --files agents/tech/coder.py agents/tech/orchestrator.py agents/creative/creative_orchestrator.py agents/tech/refactor_agent.py agents/tech/scene_builder_agent.py agents/tech/architect_agent.py agents/tech/build_agent.py agents/tech/review_agent.py agents/tech/team_lead.py agents/tech/tester.py agents/tech/feature_inspector.py agents/creative/__init__.py agents/creative/art_mood.py agents/creative/game_designer.py agents/creative/lore_keeper.py agents/creative/lore_validator.py agents/creative/narrative_designer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf930395c832082a754984928c343