### PR TITLE
Fix Slack attachments and BuildAgent mapping

### DIFF
--- a/ab_tracker.py
+++ b/ab_tracker.py
@@ -25,7 +25,7 @@ def _collect_events(feature: str, variants: list[str]) -> Dict[str, Dict[str, in
         events[v] = {
             "feature_used": random.randint(50, 100),
             "step_completed": random.randint(10, 50),
-            "error_occured": random.randint(0, 5),
+            "error_occurred": random.randint(0, 5),
         }
     return events
 
@@ -36,11 +36,11 @@ def _write_report(
     lines = ["# A/B Test Report", ""]
     for feat, variants in data.items():
         lines.append(f"## {feat}")
-        lines.append("| Variant | feature_used | step_completed | error_occured |")
+        lines.append("| Variant | feature_used | step_completed | error_occurred |")
         lines.append("|---------|--------------|----------------|---------------|")
         for variant, metrics in variants.items():
             lines.append(
-                f"| {variant} | {metrics['feature_used']} | {metrics['step_completed']} | {metrics['error_occured']} |"
+                f"| {variant} | {metrics['feature_used']} | {metrics['step_completed']} | {metrics['error_occurred']} |"
             )
         lines.append("")
         lines.append(f"**Winner:** {winners.get(feat, '-')}")

--- a/auto_fix.py
+++ b/auto_fix.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 import agent_learning
-from agents.tech import coder, refactor_agent, scene_builder_agent
+from agents.tech import coder, refactor_agent, scene_builder_agent, build_agent
 from config import UNITY_SCRIPTS_PATH
 from utils.agent_journal import log_auto_fix
 from utils.apply_patch import apply_patch
@@ -15,7 +15,7 @@ AGENT_MAP = {
     "TesterAgent": coder,
     "RefactorAgent": refactor_agent,
     "SceneBuilderAgent": scene_builder_agent,
-    "BuildAgent": refactor_agent,
+    "BuildAgent": build_agent,
 }
 
 

--- a/notify.py
+++ b/notify.py
@@ -51,14 +51,15 @@ def _send_slack(text: str, artifacts: list[str] | None = None) -> None:
         return
     try:
         data = {"text": text}
-        extra: dict[str, str] = {}
+        attachments = []
         for art in artifacts or []:
-            extra[art] = ""
+            attachments.append({"text": art})
+        if attachments:
+            data["attachments"] = attachments
         requests.post(
             url,
             json=data,
             timeout=10,
-            **extra,
         )
     except Exception as e:  # noqa: PERF203
         print(f"Slack send error: {e}")

--- a/tools/test_ab_tracker.py
+++ b/tools/test_ab_tracker.py
@@ -16,8 +16,8 @@ def test_ab_tracker_report(tmp_path, monkeypatch):
     Path("project_map.json").write_text(json.dumps(pm), encoding="utf-8")
 
     events = {
-        "A": {"feature_used": 5, "step_completed": 4, "error_occured": 1},
-        "B": {"feature_used": 6, "step_completed": 5, "error_occured": 0},
+        "A": {"feature_used": 5, "step_completed": 4, "error_occurred": 1},
+        "B": {"feature_used": 6, "step_completed": 5, "error_occurred": 0},
     }
     monkeypatch.setattr(ab_tracker, "_collect_events", lambda f, v: events)
 

--- a/tools/test_notify.py
+++ b/tools/test_notify.py
@@ -57,6 +57,6 @@ def test_notify_all(monkeypatch, tmp_path):
 
     notify.notify_all(str(summary), str(changelog), ["art.zip"])
 
-    assert any("art.zip" in v for v in events.values())
+    assert any("art.zip" in str(v) for v in events.values())
     assert any("api.telegram.org" in url for url in events)
     assert "https://slack" in events


### PR DESCRIPTION
## Summary
- capture Slack artifacts as attachments rather than request params
- map `BuildAgent` to `build_agent` in `auto_fix`
- rename `error_occured` metric to `error_occurred` in A/B tracker
- adjust tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d148d2f708320bf63b7686f6e09be