### PR TITLE
Fix backup manager recursion

### DIFF
--- a/utils/backup_manager.py
+++ b/utils/backup_manager.py
@@ -23,6 +23,7 @@ def save_backup(feature_name: str, source_path: str) -> None:
             src,
             dest,
             ignore=shutil.ignore_patterns(
+                BACKUP_ROOT.name,
                 ".backup",
                 ".git",
                 "venv",


### PR DESCRIPTION
## Summary
- prevent recursive copying of `_backups` in backup manager

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_686d2b6699b88320a6de605ad77ef6aa