### PR TITLE
Isolate Unity patch storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
-# Example .env file — do not commit your actual .env
-PROJECT_PATH=D:/Your/Unity/Project/Path/Assembly-CSharp.csproj
-UNITY_CLI=C:/Program Files/Unity/Hub/Editor/YourUnityVersion/Editor/Unity.exe
-UNITY_SCRIPTS_PATH=D:/Your/Unity/Project/Path/Assets/Scripts
-OPENAI_API_KEY=your-api-key-or-ollama
+# Путь до корня Unity проекта
+PROJECT_PATH=D:/Games/MyUnityProject
+
+# Путь до скриптов (относительно PROJECT_PATH)
+UNITY_SCRIPTS_PATH=Assets/Scripts
+
+# Путь до Unity CLI
+UNITY_CLI=C:/Program Files/Unity/Hub/Editor/6000.0.40f1/Editor/Unity.exe
+
+# Ключ OpenAI / заглушка для Ollama
+OPENAI_API_KEY=ollama

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,14 @@ final_summary.md
 /.ci_backups/
 /_backups/
 /*.log
+
+# Unity project artifacts (excluded from AI Studio)
+Assets/
+*.cs
+*.meta
+*.prefab
+*.unity
+*.asmdef
+Tests/
+_backups/
+Builds/

--- a/env.py
+++ b/env.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+
+from config import PROJECT_PATH, UNITY_SCRIPTS_PATH, UNITY_CLI, OPENAI_API_KEY
+
+
+def validate() -> bool:
+    ok = True
+    if not Path(PROJECT_PATH).exists():
+        print(f"❌ PROJECT_PATH not found: {PROJECT_PATH}")
+        ok = False
+    scripts_dir = Path(PROJECT_PATH) / UNITY_SCRIPTS_PATH
+    if not scripts_dir.exists():
+        print(f"❌ UNITY_SCRIPTS_PATH not found: {scripts_dir}")
+        ok = False
+    if not Path(UNITY_CLI).exists():
+        print(f"❌ UNITY_CLI not found: {UNITY_CLI}")
+        ok = False
+    if not OPENAI_API_KEY:
+        print("❌ OPENAI_API_KEY not set")
+        ok = False
+    return ok
+
+
+if __name__ == "__main__":
+    if validate():
+        print("✅ Environment looks OK")
+    else:
+        sys.exit(1)

--- a/tools/commit_applied_patch.py
+++ b/tools/commit_applied_patch.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import subprocess
+import sys
+
+from config import PROJECT_PATH, UNITY_SCRIPTS_PATH
+
+
+def main() -> None:
+    msg = sys.argv[1] if len(sys.argv) > 1 else "AI patch"
+    target = Path(PROJECT_PATH) / UNITY_SCRIPTS_PATH
+    subprocess.run(["git", "add", str(target)], check=True)
+    subprocess.run(["git", "commit", "-m", msg], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/apply_patch.py
+++ b/utils/apply_patch.py
@@ -1,16 +1,28 @@
 from pathlib import Path
 
-from config import UNITY_SCRIPTS_PATH
-from utils import git_tools
+from config import PROJECT_PATH, UNITY_SCRIPTS_PATH
+
+
+def normalize_path(p: str | Path) -> Path:
+    parts = Path(p).parts
+    if "Assets" in parts:
+        idx = parts.index("Assets")
+        return Path(*parts[idx:])
+    return Path(p)
 
 
 def save_to_unity_structure(modification):
     filename = modification["path"]
     content = modification["content"]
 
-    target_path = Path(UNITY_SCRIPTS_PATH) / filename
-    target_path.parent.mkdir(parents=True, exist_ok=True)
+    rel = normalize_path(filename)
+    if len(rel.parts) >= 2 and rel.parts[0] == "Assets" and rel.parts[1] in ("Scripts", "Tests"):
+        rel = Path(*rel.parts[2:])
+    elif rel.parts and rel.parts[0] in ("Scripts", "Tests"):
+        rel = Path(*rel.parts[1:])
 
+    target_path = Path(PROJECT_PATH) / UNITY_SCRIPTS_PATH / rel
+    target_path.parent.mkdir(parents=True, exist_ok=True)
     target_path.write_text(content, encoding="utf-8")
     print(f"✅ Файл сохранён в Unity проект: {target_path}")
 
@@ -19,7 +31,4 @@ def apply_patch(patch):
     for mod in patch.get("modifications", []):
         save_to_unity_structure(mod)
 
-    # git add + commit (если нужно)
-    committed = git_tools.commit_changes("AI applied patch")
-    if committed:
-        print("✅ Patch committed to git")
+    print("📝 Patch applied, but not committed. Use commit_applied_patch.py if needed.")


### PR DESCRIPTION
## Summary
- route Unity patches to external project directory only
- add manual commit tool and env validator
- keep Unity files out of repo via .gitignore
- document .env structure

## Testing
- `pre-commit run --files utils/apply_patch.py tools/commit_applied_patch.py env.py .env.example .gitignore` *(fails: command not found)*
- `pytest -q` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_686d537e70288320a39e6b0aba731349