### PR TITLE
Add SceneBuilder call

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -5,7 +5,16 @@ from pathlib import Path
 
 import agent_learning
 import agent_memory
-from agents.tech import architect_agent, build_agent, coder, game_designer, refactor_agent, review_agent, tester
+from agents.tech import (
+    architect_agent,
+    build_agent,
+    coder,
+    game_designer,
+    refactor_agent,
+    review_agent,
+    scene_builder_agent,
+    tester,
+)
 from agents.tech.project_manager import run as task_manager
 from agents.tech.tester import run as run_tests
 from auto_fix import auto_fix
@@ -94,6 +103,11 @@ def main(agents: list[str] | None = None, use_memory: bool = False):
             raise
     else:
         arch = feature
+
+    task_list = task_spec.get("tasks") or []
+    for task in task_list:
+        if task.get("attach_to_scene") is True:
+            scene_builder_agent.run({"path": arch.get("path"), **task})
 
     # 3. Код
     if not agents or "CoderAgent" in agents:


### PR DESCRIPTION
## Summary
- invoke SceneBuilderAgent in run_pipeline when a task requires attaching to scene
- tag stable pipeline as `v1.0`

## Testing
- `pre-commit run --files run_pipeline.py`
- `pytest tools/test_auto_fix.py tools/test_ci_revert.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d660a80348320a39b3d4ced0c55d7